### PR TITLE
HTMSVR-9 htm-api 모듈에 bootJar 옵션 재추가

### DIFF
--- a/htm-api/build.gradle
+++ b/htm-api/build.gradle
@@ -2,10 +2,6 @@ plugins {
     id 'java'
 }
 
-bootJar {
-    enabled = false
-}
-
 jar {
     enabled = true
 }


### PR DESCRIPTION
* enable = false 옵션을 지우고 다시 테스트합니다.