### PR TITLE
HTMSVR-17 CORS 문제 해결

### DIFF
--- a/htm-api/src/main/java/com/gachon/htm/api/configuration/WebConfiguration.java
+++ b/htm-api/src/main/java/com/gachon/htm/api/configuration/WebConfiguration.java
@@ -1,0 +1,17 @@
+package com.gachon.htm.api.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfiguration implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry
+                .addMapping("/**")
+                .allowedOrigins("*");
+        ;
+    }
+}


### PR DESCRIPTION
추가

-  cors 문제를 해결하기 위한 WebConfiguration 추가.

참고

- 임시로 모든 연결을 허용하여서 추후에 프론트 서버의 연결만을 허용하도록 수정이 필요하다.